### PR TITLE
Change the blockquote color to white.

### DIFF
--- a/user-style.css
+++ b/user-style.css
@@ -26,4 +26,7 @@
 	blockquote {
 		color: rgb(255, 255, 255) !important;
 	}
+	body.is-withMagicUnderlines .markup--anchor {
+		text-decoration: underline !important;
+	}
 }

--- a/user-style.css
+++ b/user-style.css
@@ -23,4 +23,7 @@
 	a {
 		color: #777 !important;
 	}
+	blockquote {
+		color: rgb(255, 255, 255) !important;
+	}
 }


### PR DESCRIPTION
The default color is rgba(0,0,0,0.6) and because of that it's not visible....
For example: https://medium.com/life-tips/opening-belle-e0e5b8a1bea
